### PR TITLE
INT-642: Updated Zabbix Adapter to add the prefix only once

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,7 +1,7 @@
 ** Zabbix Data Adapter
 *** Pre-requisites
 **** Zabbix
-Tested against Zabbix 2.2 with MySQL back end.
+Tested against Zabbix 3.0 with MySQL back end.
 **** Python
 - The script is written in Python
 - Tested on Python 2.7.6 and Python 3.4.0.

--- a/zabbixDBAdapter.py
+++ b/zabbixDBAdapter.py
@@ -158,7 +158,11 @@ proxy. Return the latest clock value found (which will be unchanged if rows was 
         host = replace_punctuation_and_whitespace(host)
         host = host.replace("_", ".")  # Make sure no underscore in host name
 
-        di_msg = "{0}{1} {2} {3} host={4}\n".format(ZABBIX_PREFIX, metric,
+        if metric.startswith("zabbix."):
+            di_msg = "{0}{1} {2} {3} host={4}\n".format("", metric,
+                                                    value, clock, host)
+        else:
+            di_msg = "{0}{1} {2} {3} host={4}\n".format(ZABBIX_PREFIX, metric,
                                                     value, clock, host)
 
         if clock > latest_clock:


### PR DESCRIPTION
Updated Zabbix Adapter to add the prefix `zabbix.` only once to server performance metrics.

**Example**:
earlier: `zabbix.zabbix.queue`
now: `zabbix.queue`